### PR TITLE
fix lgtm exception

### DIFF
--- a/aiokafka/consumer/assignors.py
+++ b/aiokafka/consumer/assignors.py
@@ -8,8 +8,8 @@ class AbstractStaticPartitionAssignor(AbstractPartitionAssignor):
     """
 
     @abc.abstractmethod
-    def assign(self, cluster, members,
-               member_group_instance_ids):  # lgtm[py/inheritance/signature-mismatch]
+    def assign(self, cluster, members,  # lgtm[py/inheritance/signature-mismatch]
+               member_group_instance_ids):
         """Perform group assignment given cluster metadata, member subscriptions
            and group_instance_ids
         Arguments:


### PR DESCRIPTION
LGTM docs imply that exception messages need to appear on the first line of a multi-line error, so I just moved the lgtm exception to the first line of the method definition.

### Changes

Fixes #<!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

### Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
